### PR TITLE
installed django-cors-headers

### DIFF
--- a/baketoom/settings.py
+++ b/baketoom/settings.py
@@ -60,6 +60,8 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+CSRF_TRUSTED_ORIGINS = ['baketoom.com'] # pip django-cors-headers
+
 ROOT_URLCONF = 'baketoom.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
installed django-cors-headers from pip library to fix railway.app CSRF verification failure upon POST form request.